### PR TITLE
fix: ZRegenerateSchutz var should be LOCALS only

### DIFF
--- a/ToA/base/baf/Z_2BDRA.baf
+++ b/ToA/base/baf/Z_2BDRA.baf
@@ -62,7 +62,7 @@ THEN
     RealSetGlobalTimer("ZRemoveMagic","LOCALS",5)
     RealSetGlobalTimer("ZInvisiblePerson","LOCALS",5)
     RealSetGlobalTimer("ZTalentAngriff","LOCALS",10)
-    SetGlobalTimer("ZRegenerateSchutz","GLOBAL",2400)
+    SetGlobalTimer("ZRegenerateSchutz","LOCALS",2400)
 END
 
 IF


### PR DESCRIPTION
Hi,
this is a little fix.

`ZRegenerateSchutz` is used twice. First time, it is a `GLOBAL`, second time it is a `LOCALS`. So, the dragon dont regenerate.
See here : https://github.com/Gitjas/ToA/blob/master/ToA/base/baf/Z_2BDRA.baf#L65-L69